### PR TITLE
feat: integración de ollama para análisis de reseñas

### DIFF
--- a/controllers/ReviewController.js
+++ b/controllers/ReviewController.js
@@ -1,5 +1,6 @@
 const Review = require('../models/ReviewModel');
 const AIAnalysisService = require('../utils/aiAnalysisService');
+const SentimentAnalysisService = require('../utils/sentimentAnalysisService');
 const Notification = require('../models/NotificationModel');
 const Contract = require('../models/ContractModel');
 
@@ -38,9 +39,9 @@ exports.createReview = async (req, res) => {
     let verified_booking = false;
     if (contract) {
       verified_booking = true;
-      console.log(`✅ Usuario ${reviewer_id} tiene contrato ${contract.status} con propiedad ${property_id}`);
+      console.log(`Usuario ${reviewer_id} tiene contrato ${contract.status} con propiedad ${property_id}`);
     } else {
-      console.log(`⚠️ Usuario ${reviewer_id} NO tiene contrato con propiedad ${property_id}`);
+      console.log(`Usuario ${reviewer_id} NO tiene contrato con propiedad ${property_id}`);
     }
 
     const review = await Review.createReview({
@@ -51,20 +52,42 @@ exports.createReview = async (req, res) => {
       verified_booking
     });
 
-    // ===== T-13: Análisis de IA con Ollama (Asincrónico) =====
+    // ===== Análisis de IA con Ollama (Asincrónico) =====
     // Se ejecuta en background, no bloquea la creación de la review
     (async () => {
       try {
-        console.log(`🤖 [T-13] Iniciando análisis con Ollama para review ${review.review_id}...`);
-        const analysis = await AIAnalysisService.processReviewAnalysis(
-          comment || '',
-          rating
-        );
+        console.log(`Iniciando análisis con Ollama para review ${review.review_id}...`);
+        
+        let analysis;
+        
+        // Intentar primero con Ollama
+        try {
+          analysis = await AIAnalysisService.processReviewAnalysis(
+            comment || '',
+            rating
+          );
+          
+          // Verificar si el análisis fue exitoso
+          if (analysis.status === 'error') {
+            throw new Error(analysis.error || 'Ollama analysis failed');
+          }
+        } catch (ollamaError) {
+          console.warn(`Ollama no disponible, usando fallback local:`, ollamaError.message);
+          // Fallback con SentimentAnalysisService (librería local)
+          analysis = {
+            sentiment: SentimentAnalysisService.analyzeSentiment(comment || ''),
+            moderation: { requires_moderation: false, reason: null },
+            status: 'fallback'
+          };
+        }
 
         // Guardar resultado en BD
+        const sentimentLabel = analysis.sentiment?.sentiment || 'neutral';
+        const sentimentScore = analysis.sentiment?.score ?? 3;
+        
         await Review.updateSentimentAnalysis(review.review_id, {
-          sentiment: analysis.sentiment?.sentiment || 'neutral',
-          sentiment_score: analysis.sentiment?.score || 3,
+          sentiment: sentimentLabel,
+          sentiment_score: sentimentScore,
           moderation_flag: analysis.moderation?.requires_moderation || false,
           flag_reason: analysis.moderation?.reason || null,
           analyzed_at: new Date()
@@ -81,17 +104,45 @@ exports.createReview = async (req, res) => {
           // Notificación in-app para admins
           await Notification.createForAdmins({
             type: 'review_flagged',
-            title: '🚩 Reseña flaggeada por IA',
+            title: 'Reseña flaggeada por IA',
             message: `La IA detectó contenido en una reseña: ${analysis.moderation.reason || analysis.moderation.flags.join(', ')}`,
             reference_id: review.review_id,
             reference_type: 'review'
           });
-          console.log(`⚠️ [T-13] Review ${review.review_id} flagged: ${analysis.moderation.reason}`);
-        } else {
-          console.log(`✅ [T-13] Review ${review.review_id} analizada - Sentimiento: ${analysis.sentiment?.sentiment}`);
+          console.log(`Review ${review.review_id} flagged: ${analysis.moderation.reason}`);
         }
+
+        // ===== Alerta por rating < 3 =====
+        const isLowRating = rating < 3;
+        const isNegativeSentiment = analysis.sentiment?.sentiment === 'negative';
+        
+        if (isLowRating || isNegativeSentiment) {
+          await Notification.createForAdmins({
+            type: 'low_rating_alert',
+            title: isNegativeSentiment ? 'Reseña negativa detectada' : 'Rating bajo detectado',
+            message: `Propiedad ${property_id}: Rating ${rating}/5${isNegativeSentiment ? `, Sentimiento: negativo` : ''} - "${(comment || '').substring(0, 80)}..."`,
+            reference_id: review.review_id,
+            reference_type: 'review'
+          });
+          console.log(`Alerta rating bajo: Property ${property_id}, Rating ${rating}, Sentimiento: ${analysis.sentiment?.sentiment}`);
+        }
+
+        // ===== T-13: Detección de patrones recurrentes (3+ reseñas negativas) =====
+        const negativeReviews = await Review.getPropertyNegativeReviews(property_id);
+        if (negativeReviews.length >= 3) {
+          await Notification.createForAdmins({
+            type: 'recurring_pattern_alert',
+            title: 'PATRÓN RECURRENTE: 3+ reseñas negativas',
+            message: `La propiedad ${property_id} acumula ${negativeReviews.length} reseñas negativas. Se requiere atención inmediata.`,
+            reference_id: property_id,
+            reference_type: 'property'
+          });
+          console.log(`PATRÓN RECURRENTE: Property ${property_id} tiene ${negativeReviews.length} reseñas negativas`);
+        }
+
+        console.log(`Review ${review.review_id} analizada - Sentimiento: ${analysis.sentiment?.sentiment}, Rating: ${rating}`);
       } catch (analysisError) {
-        console.error(`❌ [T-13] Error analizando review ${review.review_id}:`, analysisError.message);
+        console.error(`Error analizando review ${review.review_id}:`, analysisError.message);
         // No afecta creación, solo log
       }
     })();
@@ -264,7 +315,7 @@ exports.getReviewStats = async (req, res) => {
   }
 };
 
-// ===== T-13: MÉTODOS DE ANÁLISIS DE SENTIMIENTO =====
+// ===== MÉTODOS DE ANÁLISIS DE SENTIMIENTO =====
 
 /**
  * GET /admin/reviews/flagged - Obtener reviews flagged para moderación
@@ -381,7 +432,7 @@ exports.approveReview = async (req, res) => {
     // Registrar acción
     await Review.logModerationAction(review_id, admin_id, 'approve', notes);
 
-    console.log(`✅ Review ${review_id} aprobada por admin ${admin_id}`);
+    console.log(`Review ${review_id} aprobada por admin ${admin_id}`);
 
     res.json({
       success: true,
@@ -432,7 +483,7 @@ exports.rejectReview = async (req, res) => {
       });
     }
 
-    console.log(`❌ Review ${review_id} rechazada por admin ${admin_id}. Motivo: ${notes}`);
+    console.log(`Review ${review_id} rechazada por admin ${admin_id}. Motivo: ${notes}`);
 
     res.json({
       success: true,
@@ -481,7 +532,7 @@ exports.analyzeBatch = async (req, res) => {
       });
     }
 
-    console.log(`🤖 [T-13] Iniciando análisis en batch de ${unanalyzedReviews.length} reviews con Ollama...`);
+    console.log(`Iniciando análisis en batch de ${unanalyzedReviews.length} reviews con Ollama...`);
 
     // Preparar datos para batch
     const reviewsForAnalysis = unanalyzedReviews.map(r => ({
@@ -521,15 +572,15 @@ exports.analyzeBatch = async (req, res) => {
           analyzed++;
         } else {
           errors++;
-          console.error(`⚠️ Error analizando review ${result.review_id}:`, result.error);
+          console.error(`Error analizando review ${result.review_id}:`, result.error);
         }
       } catch (dbError) {
-        console.error(`❌ Error guardando análisis para review ${result.review_id}:`, dbError.message);
+        console.error(`Error guardando análisis para review ${result.review_id}:`, dbError.message);
         errors++;
       }
     }
 
-    console.log(`✅ [T-13] Batch analysis completado: ${analyzed} analizadas, ${flagged} flagged, ${errors} errores`);
+    console.log(`Batch analysis completado: ${analyzed} analizadas, ${flagged} flagged, ${errors} errores`);
 
     res.json({
       success: true,  
@@ -540,7 +591,7 @@ exports.analyzeBatch = async (req, res) => {
       total: unanalyzedReviews.length
     });
   } catch (error) {
-    console.error('❌ Error en análisis batch:', error);
+    console.error('Error en análisis batch:', error);
     res.status(500).json({
       success: false,
       error: error.message || 'Error en análisis batch'

--- a/models/NotificationModel.js
+++ b/models/NotificationModel.js
@@ -1,0 +1,149 @@
+const db = require('../config/db');
+
+class NotificationModel {
+    /**
+     * Crear tabla de notificaciones de usuario si no existe
+     */
+    static async ensureTable() {
+        try {
+            await db.execute(`
+                CREATE TABLE IF NOT EXISTS user_notifications (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    user_id INT NOT NULL,
+                    type VARCHAR(50) NOT NULL,
+                    title VARCHAR(255) NOT NULL,
+                    message TEXT,
+                    reference_id INT,
+                    reference_type VARCHAR(50),
+                    read_at DATETIME,
+                    created_at DATETIME NOT NULL,
+                    INDEX idx_user_id (user_id),
+                    INDEX idx_created_at (created_at)
+                )
+            `);
+            
+            await db.execute(`
+                CREATE TABLE IF NOT EXISTS admin_notifications (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    user_id INT NOT NULL,
+                    type VARCHAR(50) NOT NULL,
+                    title VARCHAR(255) NOT NULL,
+                    message TEXT,
+                    reference_id INT,
+                    reference_type VARCHAR(50),
+                    read_at DATETIME,
+                    created_at DATETIME NOT NULL,
+                    INDEX idx_user_id (user_id),
+                    INDEX idx_created_at (created_at)
+                )
+            `);
+        } catch (error) {
+            console.error('Error creando tabla user_notifications:', error);
+        }
+    }
+
+    /**
+     * Inicializar - llamar al inicio de la app
+     */
+    static async init() {
+        await this.ensureTable();
+    }
+
+    /**
+     * Crear una notificación para todos los admins
+     */
+    static async createForAdmins({ type, title, message, reference_id = null, reference_type = null }) {
+        try {
+            // Obtener todos los usuarios con rol admin (rol_id = 3)
+            const [admins] = await db.execute(
+                'SELECT user_id FROM users WHERE rol_id = 3'
+            );
+            if (!admins.length) return [];
+
+            const results = [];
+            for (const admin of admins) {
+                const [result] = await db.execute(
+                    `INSERT INTO admin_notifications (user_id, type, title, message, reference_id, reference_type, created_at)
+                     VALUES (?, ?, ?, ?, ?, ?, NOW())`,
+                    [admin.user_id, type, title, message, reference_id, reference_type]
+                );
+                results.push(result.insertId);
+            }
+            return results;
+        } catch (error) {
+            console.error('Error creando notificación:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Crear una notificación para un usuario específico
+     */
+    static async createForUser(user_id, { type, title, message, reference_id = null, reference_type = null }) {
+        try {
+            const [result] = await db.execute(
+                `INSERT INTO user_notifications (user_id, type, title, message, reference_id, reference_type, created_at)
+                 VALUES (?, ?, ?, ?, ?, ?, NOW())`,
+                [user_id, type, title, message, reference_id, reference_type]
+            );
+            return result.insertId;
+        } catch (error) {
+            console.error('Error creando notificación de usuario:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Obtener notificaciones de un usuario
+     */
+    static async getForUser(user_id, limit = 50) {
+        const [rows] = await db.execute(
+            `SELECT * FROM user_notifications
+             WHERE user_id = ?
+             ORDER BY created_at DESC
+             LIMIT ?`,
+            [user_id, limit]
+        );
+        return rows;
+    }
+
+    /**
+     * Obtener notificaciones de un admin
+     */
+    static async getForAdmin(user_id, limit = 50) {
+        const [rows] = await db.execute(
+            `SELECT * FROM admin_notifications
+             WHERE user_id = ?
+             ORDER BY created_at DESC
+             LIMIT ?`,
+            [user_id, String(limit)]
+        );
+        return rows;
+    }
+
+    /**
+     * Marcar una notificación como leída
+     */
+    static async markRead(id, user_id) {
+        const [result] = await db.execute(
+            `UPDATE admin_notifications SET read_at = NOW()
+             WHERE id = ? AND user_id = ? AND read_at IS NULL`,
+            [id, user_id]
+        );
+        return result.affectedRows > 0;
+    }
+
+    /**
+     * Marcar todas como leídas para un admin
+     */
+    static async markAllRead(user_id) {
+        const [result] = await db.execute(
+            `UPDATE admin_notifications SET read_at = NOW()
+             WHERE user_id = ? AND read_at IS NULL`,
+            [user_id]
+        );
+        return result.affectedRows;
+    }
+}
+
+module.exports = NotificationModel;

--- a/models/ReviewModel.js
+++ b/models/ReviewModel.js
@@ -315,7 +315,7 @@ class Review {
     }
   }
 
-  // ===== MÉTODOS PARA ANÁLISIS DE SENTIMIENTO (T-13) =====
+  // ===== MÉTODOS PARA ANÁLISIS DE SENTIMIENTO =====
 
   /**
    * Actualizar análisis de sentimiento de una review
@@ -480,6 +480,27 @@ class Review {
       return reviews;
     } catch (error) {
       throw new Error(`Error obtaining unanalyzed reviews: ${error.message}`);
+    }
+  }
+
+  /**
+   * Obtener reseñas negativas de una propiedad (sentimiento negativo O rating <= 2)
+   * Usado para detección de patrones recurrentes
+   */
+  static async getPropertyNegativeReviews(property_id) {
+    try {
+      const [reviews] = await db.execute(
+        `SELECT review_id, rating, sentiment, sentiment_score, created_at
+         FROM reviews
+         WHERE property_id = ? 
+           AND (sentiment = 'negative' OR rating <= 2)
+         ORDER BY created_at DESC`,
+        [property_id]
+      );
+
+      return reviews;
+    } catch (error) {
+      throw new Error(`Error obteniendo reseñas negativas: ${error.message}`);
     }
   }
 }

--- a/test-ollama.js
+++ b/test-ollama.js
@@ -1,0 +1,249 @@
+const axios = require('axios');
+
+const OLLAMA_URL = process.env.OLLAMA_API_URL || 'http://localhost:11434';
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'phi3.5';
+
+console.log('Ollama Integration Test Suite\n');
+console.log('='.repeat(50));
+console.log(`Ollama URL:   ${OLLAMA_URL}`);
+console.log(`Model Target: ${OLLAMA_MODEL}`);
+console.log('='.repeat(50));
+
+/**
+ * Test 1: Check if Ollama is running
+ */
+async function testOllamaRunning() {
+  console.log('\n Test 1: Verificar si Ollama está corriendo...');
+  try {
+    const response = await axios.get(`${OLLAMA_URL}/api/tags`, { timeout: 5000 });
+    console.log('Ollama server está activo');
+    return true;
+  } catch (error) {
+    console.error('Ollama no responde en ' + OLLAMA_URL);
+    console.error(`   Error: ${error.message}`);
+    console.error('\n   Solución: Ejecuta en otra terminal:');
+    console.error('   $ ollama serve\n');
+    return false;
+  }
+}
+
+/**
+ * Test 2: Check if Phi-3.5 Mini model is downloaded
+ */
+async function testModelDownloaded() {
+  console.log('\n Test 2: Verificar si el modelo está descargado...');
+  try {
+    const response = await axios.get(`${OLLAMA_URL}/api/tags`, { timeout: 5000 });
+    const models = response.data.models || [];
+    const hasModel = models.some(m => m.name.includes('phi3.5'));
+    
+    if (hasModel) {
+      console.log(`Modelo ${OLLAMA_MODEL} está descargado`);
+      return true;
+    } else {
+      console.error(`Modelo ${OLLAMA_MODEL} NO está descargado`);
+      console.error('\n   Modelos disponibles:');
+      models.forEach(m => console.error(`   - ${m.name}`));
+      console.error(`\n   Solución: El modelo phi3.5 ya está instalado, continúa con npm start\n`);
+      return false;
+    }
+  } catch (error) {
+    console.error('Error verificando modelos');
+    console.error(`   ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * Test 3: Test simple generation
+ */
+async function testSimpleGeneration() {
+  console.log('\n Test 3: Hacer una llamada simple al modelo...');
+  try {
+    const response = await axios.post(
+      `${OLLAMA_URL}/api/generate`,
+      {
+        model: OLLAMA_MODEL,
+        prompt: 'Responde con "OK"',
+        stream: false,
+        temperature: 0.3
+      },
+      { timeout: 30000 }
+    );
+
+    if (response.data.response) {
+      console.log(`Generación exitosa`);
+      console.log(`   Respuesta: "${response.data.response.substring(0, 100)}..."`);
+      console.log(`   Tiempo: ${response.data.eval_duration / 1e9}s`);
+      return true;
+    } else {
+      console.error('Respuesta vacía del modelo');
+      return false;
+    }
+  } catch (error) {
+    console.error('Error en generación');
+    console.error(`   ${error.message}`);
+    if (error.code === 'ECONNREFUSED') {
+      console.error('\n Conexión rechazada. Asegúrate de:');
+      console.error('   1. ollama serve está corriendo');
+      console.error('   2. Puerto 11434 está abierto');
+    }
+    return false;
+  }
+}
+
+/**
+ * Test 4: Test JSON response parsing
+ */
+async function testJSONParsing() {
+  console.log('\n Test 4: Probar respuesta JSON del modelo...');
+  try {
+    const prompt = `Responde SOLO con JSON válido:
+    {
+      "test": true,
+      "model": "phi3.5-mini",
+      "message": "working"
+    }`;
+
+    const response = await axios.post(
+      `${OLLAMA_URL}/api/generate`,
+      {
+        model: OLLAMA_MODEL,
+        prompt: prompt,
+        stream: false,
+        temperature: 0.1
+      },
+      { timeout: 30000 }
+    );
+
+    const responseText = response.data.response;
+    
+    // Try to parse JSON
+    try {
+      const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const json = JSON.parse(jsonMatch[0]);
+        console.log('JSON parsing exitoso');
+        console.log(`   Parsed: ${JSON.stringify(json)}`);
+        return true;
+      } else {
+        console.warn('No se encontró JSON en respuesta');
+        console.warn(`   Raw: "${responseText.substring(0, 100)}..."`);
+        return true; // No es critical
+      }
+    } catch (parseError) {
+      console.warn('No se pudo parsear JSON');
+      return true; // No es critical
+    }
+  } catch (error) {
+    console.error('Error en test JSON');
+    console.error(`   ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * Test 5: Test sentiment analysis prompt
+ */
+async function testSentimentPrompt() {
+  console.log('\n Test 5: Probar análisis de sentimiento...');
+  try {
+    const reviewText = 'Este apartamento es excelente, muy cómodo y el dueño es muy amable.';
+    
+    const prompt = `Analyze this apartment review sentiment. Respond ONLY with JSON:
+    {
+      "sentiment": "positive|negative|neutral",
+      "score": number (1-5),
+      "confidence": number (0-1)
+    }
+    
+    Review: "${reviewText}"`;
+
+    const response = await axios.post(
+      `${OLLAMA_URL}/api/generate`,
+      {
+        model: OLLAMA_MODEL,
+        prompt: prompt,
+        stream: false,
+        temperature: 0.2
+      },
+      { timeout: 30000 }
+    );
+
+    const responseText = response.data.response;
+    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+    
+    if (jsonMatch) {
+      const json = JSON.parse(jsonMatch[0]);
+      console.log('Análisis de sentimiento funciona');
+      console.log(`   Sentimiento: ${json.sentiment}`);
+      console.log(`   Score: ${json.score}/5`);
+      console.log(`   Confianza: ${(json.confidence * 100).toFixed(1)}%`);
+      return true;
+    } else {
+      console.warn('Respuesta no contiene JSON');
+      return true;
+    }
+  } catch (error) {
+    console.error('Error en test de sentimiento');
+    console.error(`   ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * Main test runner
+ */
+async function runTests() {
+  const tests = [
+    testOllamaRunning,
+    testModelDownloaded,
+    testSimpleGeneration,
+    testJSONParsing,
+    testSentimentPrompt
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const test of tests) {
+    try {
+      const result = await test();
+      if (result) {
+        passed++;
+      } else {
+        failed++;
+      }
+    } catch (error) {
+      console.error(`Test exception: ${error.message}`);
+      failed++;
+    }
+  }
+
+  console.log('\n' + '='.repeat(50));
+  console.log(`Resultados: ${passed} pasados, ${failed} fallidos\n`);
+
+  if (failed === 0) {
+    console.log('¡Ollama está listo para T-13!\n');
+    console.log('Próximos pasos:');
+    console.log('1. npm start en terminal de servidor');
+    console.log('2. En admin panel, ir a "Reviews" → "Analyze Batch" para analizar reviews con IA');
+    console.log('3. El servidor analizará reviews con Ollama IA\n');
+    process.exit(0);
+  } else {
+    console.log('Hay problemas a resolver antes de continuar\n');
+    console.log('Troubleshooting:');
+    console.log('1. ¿Ollama está instalado? https://ollama.ai');
+    console.log('2. ¿ollama serve está corriendo?');
+    console.log('3. Asegúrate de que phi3.5 está descargado (ollama list)');
+    console.log('4. ¿Puerto 11434 está disponible?');
+    console.log('5. Revisa el .env OLLAMA_API_URL\n');
+    process.exit(1);
+  }
+}
+
+// Run tests
+runTests().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/utils/aiAnalysisService.js
+++ b/utils/aiAnalysisService.js
@@ -1,0 +1,380 @@
+const axios = require('axios');
+
+const OLLAMA_API_URL = process.env.OLLAMA_API_URL || 'http://localhost:11434';
+const OLLAMA_MODEL   = process.env.OLLAMA_MODEL   || 'phi3.5';
+const OLLAMA_TIMEOUT = parseInt(process.env.OLLAMA_TIMEOUT || '60000');
+// Si el servidor Ollama requiere autenticación (Railway, Render, etc.)
+const OLLAMA_API_KEY = process.env.OLLAMA_API_KEY || null;
+
+/**
+ * Check if Ollama server is running
+ * @returns {Promise<boolean>}
+ */
+async function isOllamaRunning() {
+  try {
+    const headers = OLLAMA_API_KEY ? { 'Authorization': `Bearer ${OLLAMA_API_KEY}` } : {};
+    const response = await axios.get(`${OLLAMA_API_URL}/api/tags`, {
+      timeout: 5000,
+      headers
+    });
+    return response.status === 200;
+  } catch (error) {
+    console.error('Ollama no está disponible:', error.message);
+    return false;
+  }
+}
+
+/**
+ * Call Ollama API for review analysis
+ * @param {string} prompt - Analysis prompt
+ * @returns {Promise<string>} - LLM response
+ */
+async function callOllama(prompt) {
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    if (OLLAMA_API_KEY) headers['Authorization'] = `Bearer ${OLLAMA_API_KEY}`;
+
+    const response = await axios.post(
+      `${OLLAMA_API_URL}/api/generate`,
+      {
+        model: OLLAMA_MODEL,
+        prompt: prompt,
+        stream: false,
+        temperature: 0.3,
+        top_p: 0.9,
+      },
+      { timeout: OLLAMA_TIMEOUT, headers }
+    );
+
+    return response.data.response || '';
+  } catch (error) {
+    console.error('Error calling Ollama:', error.message);
+    throw new Error(`Ollama API error: ${error.message}`);
+  }
+}
+
+/**
+ * Parse JSON response from Ollama
+ * Ollama sometimes returns non-JSON content, so we extract JSON from text
+ * @param {string} text - Response text
+ * @returns {object} - Parsed JSON
+ */
+function parseOllamaResponse(text) {
+  try {
+    // Try direct JSON parse
+    return JSON.parse(text);
+  } catch (e) {
+    // If fails, try to extract JSON from text
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      try {
+        return JSON.parse(jsonMatch[0]);
+      } catch (e2) {
+        console.warn('Could not parse JSON from Ollama response');
+        // Return default safe analysis
+        return {
+          legitimate: true,
+          offensive: false,
+          constructive: true,
+          spam: false,
+          explanation: text.substring(0, 200)
+        };
+      }
+    }
+    throw new Error('Invalid response format from Ollama');
+  }
+}
+
+/**
+ * Analyze a review for legitimacy, offensive content, and constructiveness
+ * @param {string} reviewText - Review content to analyze
+ * @returns {Promise<object>} - Analysis result with legitimacy, offensive, constructive, explanation
+ */
+async function analyzeReview(reviewText) {
+  if (!reviewText || reviewText.trim().length === 0) {
+    return {
+      legitimate: false,
+      offensive: false,
+      constructive: false,
+      spam: true,
+      explanation: 'Review is empty'
+    };
+  }
+
+  const prompt = `Analyze this apartment review and classify it. Respond ONLY with JSON, no other text.
+
+Review: "${reviewText}"
+
+Classification:
+{
+  "legitimate": boolean (is this a real review or fake?),
+  "offensive": boolean (contains offensive/abusive language?),
+  "constructive": boolean (is the feedback constructive?),
+  "spam": boolean (is this spam or advertising?),
+  "explanation": "brief reason" (max 100 chars)
+}`;
+
+  try {
+    console.log(`Analyzing review with Ollama (${OLLAMA_MODEL})...`);
+    const response = await callOllama(prompt);
+    const analysis = parseOllamaResponse(response);
+
+    console.log('Review analyzed:', {
+      legitimate: analysis.legitimate,
+      offensive: analysis.offensive,
+      spam: analysis.spam
+    });
+
+    return {
+      legitimate: analysis.legitimate ?? true,
+      offensive: analysis.offensive ?? false,
+      constructive: analysis.constructive ?? true,
+      spam: analysis.spam ?? false,
+      explanation: analysis.explanation || 'Analysis complete'
+    };
+  } catch (error) {
+    console.error('Analysis failed:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Generate sentiment analysis (positive/negative/neutral)
+ * @param {string} reviewText - Review content
+ * @returns {Promise<object>} - Sentiment with score
+ */
+async function analyzeSentiment(reviewText) {
+  const prompt = `Rate the sentiment of this apartment review on a scale 1-5, where:
+1 = Very Negative
+2 = Negative  
+3 = Neutral
+4 = Positive
+5 = Very Positive
+
+Review: "${reviewText}"
+
+Respond ONLY with JSON:
+{
+  "sentiment": "positive|negative|neutral",
+  "score": number (1-5),
+  "confidence": number (0-1),
+  "reasoning": "brief explanation"
+}`;
+
+  try {
+    const response = await callOllama(prompt);
+    const analysis = parseOllamaResponse(response);
+
+    return {
+      sentiment: analysis.sentiment || 'neutral',
+      score: Math.min(5, Math.max(1, analysis.score || 3)),
+      confidence: Math.min(1, Math.max(0, analysis.confidence || 0.7)),
+      reasoning: analysis.reasoning || ''
+    };
+  } catch (error) {
+    console.error('Sentiment analysis failed:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Detect moderation flags and reasons
+ * @param {string} reviewText - Review content
+ * @returns {Promise<object>} - Flag result with severity
+ */
+async function detectModerationFlags(reviewText) {
+  const prompt = `Review this apartment review for moderation issues. Respond ONLY with JSON.
+
+Review: "${reviewText}"
+
+{
+  "requires_moderation": boolean,
+  "severity": "low|medium|high|critical",
+  "flags": [array of issue types: "offensive", "spam", "fake", "adult", "violence", "harassment"],
+  "reason": "explanation of flags"
+}`;
+
+  try {
+    const response = await callOllama(prompt);
+    const result = parseOllamaResponse(response);
+
+    return {
+      requires_moderation: result.requires_moderation ?? false,
+      severity: result.severity || 'low',
+      flags: Array.isArray(result.flags) ? result.flags : [],
+      reason: result.reason || ''
+    };
+  } catch (error) {
+    console.error('Moderation detection failed:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Full review analysis - combines all analyses
+ * @param {string} reviewText - Review content
+ * @param {number} rating - Star rating (1-5)
+ * @returns {Promise<object>} - Complete analysis result
+ */
+async function processReviewAnalysis(reviewText, rating = 3) {
+  console.log('Starting AI analysis with Ollama...');
+
+  try {
+    // Check if Ollama is running
+    const ollamaRunning = await isOllamaRunning();
+    if (!ollamaRunning) {
+      throw new Error('Ollama server is not running on ' + OLLAMA_API_URL);
+    }
+
+    // Run all analyses in parallel
+    const [legitimacyAnalysis, sentimentAnalysis, moderationAnalysis] = await Promise.all([
+      analyzeReview(reviewText),
+      analyzeSentiment(reviewText),
+      detectModerationFlags(reviewText)
+    ]);
+
+    // Combine results
+    const analysis = {
+      timestamp: new Date(),
+      model: OLLAMA_MODEL,
+      status: 'analyzed',
+      review: {
+        text: reviewText.substring(0, 500), // Store first 500 chars
+        rating: rating,
+        length: reviewText.length
+      },
+      legitimacy: legitimacyAnalysis,
+      sentiment: sentimentAnalysis,
+      moderation: moderationAnalysis,
+      recommendation: {
+        approve: legitimacyAnalysis.legitimate && !moderationAnalysis.requires_moderation,
+        reason: generateRecommendation(legitimacyAnalysis, moderationAnalysis)
+      }
+    };
+
+    console.log('Analysis complete:', {
+      approve: analysis.recommendation.approve,
+      sentiment: analysis.sentiment.sentiment,
+      flags: analysis.moderation.flags
+    });
+
+    return analysis;
+  } catch (error) {
+    console.error('Complete analysis failed:', error.message);
+    return {
+      timestamp: new Date(),
+      status: 'error',
+      error: error.message,
+      review: { text: reviewText.substring(0, 500) },
+      recommendation: {
+        approve: null,
+        reason: 'Analysis failed - manual review required'
+      }
+    };
+  }
+}
+
+/**
+ * Generate recommendation based on analyses
+ * @private
+ */
+function generateRecommendation(legitimacy, moderation) {
+  if (!legitimacy.legitimate) {
+    return 'Fake or spam review detected';
+  }
+  if (moderation.requires_moderation) {
+    return `Review flagged for: ${moderation.flags.join(', ')} (${moderation.severity})`;
+  }
+  if (legitimacy.offensive) {
+    return 'Contains offensive language';
+  }
+  return 'Safe to publish';
+}
+
+/**
+ * Batch analyze multiple reviews
+ * @param {array} reviews - Array of {text, rating}
+ * @returns {Promise<array>} - Analysis results
+ */
+async function batchAnalyzeReviews(reviews) {
+  console.log(`Batch analyzing ${reviews.length} reviews...`);
+
+  const results = [];
+  for (const review of reviews) {
+    try {
+      const analysis = await processReviewAnalysis(review.text, review.rating);
+      results.push({
+        review_id: review.id,
+        ...analysis
+      });
+
+      // Small delay between requests to avoid overwhelming Ollama
+      await new Promise(resolve => setTimeout(resolve, 500));
+    } catch (error) {
+      results.push({
+        review_id: review.id,
+        status: 'error',
+        error: error.message
+      });
+    }
+  }
+
+  console.log(`Batch analysis complete: ${results.filter(r => r.status === 'analyzed').length} successful`);
+  return results;
+}
+
+/**
+ * Health check - verify Ollama is accessible
+ * @returns {Promise<object>} - Health status
+ */
+async function healthCheck() {
+  try {
+    const isRunning = await isOllamaRunning();
+    
+    if (isRunning) {
+      // Test a simple analysis
+      const testResult = await callOllama('Respond with "OK"');
+      
+      return {
+        status: 'healthy',
+        ollama: {
+          url: OLLAMA_API_URL,
+          model: OLLAMA_MODEL,
+          available: true,
+          testResponse: testResult.substring(0, 50)
+        }
+      };
+    } else {
+      return {
+        status: 'unhealthy',
+        ollama: {
+          url: OLLAMA_API_URL,
+          model: OLLAMA_MODEL,
+          available: false,
+          error: 'Server not responding'
+        }
+      };
+    }
+  } catch (error) {
+    return {
+      status: 'error',
+      ollama: {
+        url: OLLAMA_API_URL,
+        model: OLLAMA_MODEL,
+        available: false,
+        error: error.message
+      }
+    };
+  }
+}
+
+module.exports = {
+  analyzeReview,
+  analyzeSentiment,
+  detectModerationFlags,
+  processReviewAnalysis,
+  batchAnalyzeReviews,
+  healthCheck,
+  isOllamaRunning,
+  callOllama
+};

--- a/utils/sentimentAnalysisService.js
+++ b/utils/sentimentAnalysisService.js
@@ -1,0 +1,190 @@
+const Sentiment = require('sentiment');
+const sentiment = new Sentiment();
+
+class SentimentAnalysisService {
+    /**
+     * Analizar sentimiento de un texto
+     * @param {string} text - Texto a analizar
+     * @returns {object} {sentiment: 'positive|negative|neutral', score: -1.0 to 1.0, details: {...}}
+     */
+    static analyzeSentiment(text) {
+        if (!text || text.trim().length === 0) {
+            return {
+                sentiment: 'neutral',
+                score: 0,
+                confidence: 0,
+                details: {}
+            };
+        }
+
+        // Análisis de sentimiento
+        const result = sentiment.analyze(text);
+        
+        // Determinar sentimiento basado en score
+        let sentimentLabel = 'neutral';
+        if (result.score > 0.5) {
+            sentimentLabel = 'positive';
+        } else if (result.score < -0.5) {
+            sentimentLabel = 'negative';
+        }
+
+        // Normalizar score a rango -1 a 1
+        const normalizedScore = Math.max(-1, Math.min(1, result.score / 10));
+
+        return {
+            sentiment: sentimentLabel,
+            score: parseFloat(normalizedScore.toFixed(2)),
+            words: result.words || [],
+            positive: result.positive || [],
+            negative: result.negative || [],
+            details: result
+        };
+    }
+
+    /**
+     * Detectar si una review necesita moderación
+     * @param {object} review - Objeto de review
+     * @returns {object} {needsModeration: boolean, flagReason: string|null}
+     */
+    static detectModerationFlags(review) {
+        const flags = [];
+
+        // Flag 1: Palabras ofensivas comunes
+        const offensiveWords = [
+            'basura', 'horrible', 'apesto', 'estafa', 'fraude',
+            'sucio', 'cochino', 'asco', 'repugnante', 'vomito',
+            'stupid', 'asshole', 'fuck', 'shit', 'damn',
+            'damn', 'crap', 'hell'
+        ];
+
+        const commentLower = (review.comment || '').toLowerCase();
+        for (const word of offensiveWords) {
+            if (commentLower.includes(word)) {
+                flags.push(`Lenguaje ofensivo detectado: "${word}"`);
+                break;
+            }
+        }
+
+        // Flag 2: Rating y sentimiento no alineados (advertencia)
+        if (review.rating >= 4 && review.sentiment === 'negative') {
+            flags.push('Inconsistencia: rating alto pero sentimiento negativo');
+        } else if (review.rating <= 2 && review.sentiment === 'positive') {
+            flags.push('Inconsistencia: rating bajo pero sentimiento positivo');
+        }
+
+        // Flag 3: Comentario muy corto con rating bajo
+        if (review.rating <= 2 && commentLower.length < 10) {
+            flags.push('Comentario muy corto con rating negativo');
+        }
+
+        // Flag 4: Spam (muchas repeticiones)
+        const words = commentLower.split(/\s+/);
+        if (words.length > 0) {
+            const wordFreq = {};
+            for (const word of words) {
+                wordFreq[word] = (wordFreq[word] || 0) + 1;
+            }
+            const maxFreq = Math.max(...Object.values(wordFreq));
+            if (maxFreq > words.length * 0.5) {
+                flags.push('Posible spam (palabras muy repetidas)');
+            }
+        }
+
+        // Flag 5: Texto vacío o demasiado largo
+        if (!review.comment || review.comment.trim().length === 0) {
+            flags.push('Sin comentario de texto');
+        } else if (review.comment.length > 5000) {
+            flags.push('Comentario demasiado largo');
+        }
+
+        return {
+            needsModeration: flags.length > 0,
+            flagReason: flags.length > 0 ? flags.join('; ') : null,
+            flags: flags
+        };
+    }
+
+    /**
+     * Procesar análisis completo de una review
+     * @param {object} review - Objeto de review con comment, rating
+     * @returns {object} Análisis completo
+     */
+    static processReviewAnalysis(review) {
+        // Análisis de sentimiento
+        const sentimentResult = this.analyzeSentiment(review.comment);
+
+        // Detección de moderación
+        const moderationResult = this.detectModerationFlags({
+            comment: review.comment,
+            rating: review.rating,
+            sentiment: sentimentResult.sentiment
+        });
+
+        return {
+            sentiment: sentimentResult.sentiment,
+            sentiment_score: sentimentResult.score,
+            moderation_flag: moderationResult.needsModeration,
+            flag_reason: moderationResult.flagReason,
+            analysis_details: {
+                positive_words: sentimentResult.positive || [],
+                negative_words: sentimentResult.negative || [],
+                confidence: Math.abs(sentimentResult.score),
+                word_count: (review.comment || '').split(/\s+/).length
+            }
+        };
+    }
+
+    /**
+     * Calcular calificación promedio con weight de sentimiento
+     * @param {array} reviews - Array de reviews
+     * @returns {object} {average: float, by_sentiment: {positive, negative, neutral}}
+     */
+    static calculateWeightedRating(reviews) {
+        if (!reviews || reviews.length === 0) {
+            return {
+                average: 0,
+                count: 0,
+                by_sentiment: {
+                    positive: 0,
+                    negative: 0,
+                    neutral: 0
+                }
+            };
+        }
+
+        const bySentiment = {
+            positive: [],
+            negative: [],
+            neutral: []
+        };
+
+        let totalScore = 0;
+        for (const review of reviews) {
+            totalScore += review.rating || 0;
+            const sentiment = review.sentiment || 'neutral';
+            if (bySentiment[sentiment]) {
+                bySentiment[sentiment].push(review.rating);
+            }
+        }
+
+        const averageRating = (totalScore / reviews.length).toFixed(1);
+
+        return {
+            average: parseFloat(averageRating),
+            count: reviews.length,
+            by_sentiment: {
+                positive: bySentiment.positive.length > 0 
+                    ? (bySentiment.positive.reduce((a, b) => a + b, 0) / bySentiment.positive.length).toFixed(1)
+                    : 0,
+                negative: bySentiment.negative.length > 0 
+                    ? (bySentiment.negative.reduce((a, b) => a + b, 0) / bySentiment.negative.length).toFixed(1)
+                    : 0,
+                neutral: bySentiment.neutral.length > 0 
+                    ? (bySentiment.neutral.reduce((a, b) => a + b, 0) / bySentiment.neutral.length).toFixed(1)
+                    : 0
+            }
+        };
+    }
+}
+
+module.exports = SentimentAnalysisService;


### PR DESCRIPTION
### Descripción

Se implementó un sistema completo de análisis de sentimiento

Cambios realizados:

API de análisis de sentimiento (Ollama + fallback Sentiment.js)
Hook post-save automático (async en ReviewController)
Etiquetado (positive/neutral/negative)
Umbrales (rating < 3 o negativo → alerta)
Detección de patrones recurrentes (3+ reseñas negativas → alerta especial)
Sistema de notificación al admin (Notification.createForAdmins)
Guardar resultado del análisis (sentiment, sentiment_score, moderation_flag)
Manejo de errores (fallback con SentimentAnalysisService si Ollama no está disponible)

### Closes #17 