### PR TITLE
fix: pin pnpm a v9 para evitar bloqueo de build scripts en v11

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: latest
+        version: 9
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-slim
 WORKDIR /app
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@9 --activate
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install
 COPY . .


### PR DESCRIPTION
### Descripción

Se cambio a v9 para evitar bloqueo de la última versión