### PR TITLE
fix: cambiar certs/firebase-service-account.json a certs/ en dockerig

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,4 @@ README.md
 CODEOWNERS
 coverage
 __tests__
-certs/firebase-service-account.json
+certs/

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,7 +38,7 @@ jobs:
       run: pnpm install --frozen-lockfile
 
     - name: Run unit tests
-      run: pnpm test:unit || true
+      run: pnpm test:unit
       env:
         NODE_ENV: test
         DB_HOST: localhost
@@ -51,7 +51,7 @@ jobs:
         ENCRYPTION_KEY: 0a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p
 
     - name: Run integration tests
-      run: pnpm test:integration || true
+      run: pnpm test:integration
       env:
         NODE_ENV: test
         DB_HOST: localhost


### PR DESCRIPTION
### Descripción

Se cambio que no construya la imagen con ningún archivo de certs/ y que el paso de tests falle si da error en un test de la suite